### PR TITLE
Fixed version of django-storages to work with Django 1.6.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -92,7 +92,7 @@ dj-static==0.0.6
 # Ref: http://docs.pythonboto.org/en/latest/
 boto==2.32
 # Ref: https://django-storages.readthedocs.org/en/latest/
-django-storages
+django-storages==1.1.8
 # Ref: https://github.com/jamstooks/django-s3-folder-storage
 django-s3-folder-storage==0.2
 


### PR DESCRIPTION
Higher versions of django-storages stop the site running locally when the DEBUG flag is False. Fixing it at the old version to keep Django 1.6 support for now.